### PR TITLE
Move to first column instead of first char of line

### DIFF
--- a/plugin/movement.vim
+++ b/plugin/movement.vim
@@ -4,7 +4,7 @@
 "beginning-of-line (C-a)
 "Move to the start of the current line.
 function! ReadlineBeginningOfLine()
-  call feedkeys("\<C-O>^")
+  call feedkeys("\<C-O>0")
 endfunction
 command! ReadlineBeginningOfLine call ReadlineBeginningOfLine()
 


### PR DESCRIPTION
This helps with soft-wrapped lines. It also fixes an inconsistency
between C-e and C-a on wrapped lines.

Fixes #6 